### PR TITLE
feature: include components path to babel loader

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -93,6 +93,7 @@ module.exports = function(env, args) {
           include: [
             path.resolve('./Resources/Private/Javascript'),
             path.resolve(`${basePackagePathAbsolute()}/Resources/Private/Javascript/`),
+            path.resolve(`${basePackagePathAbsolute()}/Resources/Private/Components`),
             /node_modules/
           ],
           exclude: /@babel(?:\/|\\{1,2})runtime|pdfjs-dist/,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -90,12 +90,6 @@ module.exports = function(env, args) {
         },
         {
           test: /\.js?$/,
-          include: [
-            path.resolve('./Resources/Private/Javascript'),
-            path.resolve(`${basePackagePathAbsolute()}/Resources/Private/Javascript/`),
-            path.resolve(`${basePackagePathAbsolute()}/Resources/Private/Components`),
-            /node_modules/
-          ],
           exclude: /@babel(?:\/|\\{1,2})runtime|pdfjs-dist/,
           loader: require.resolve('babel-loader'),
           options: {


### PR DESCRIPTION
Right now there are some issues with arrow function features when javascript files are imported from the `~baseComponents` folder. 

I suggest to also include the `Components` folder to the `babel-loader` module as this resolves the issue. 

This feature is important as the future approach is to handle plugins as components. So we need a workaround to handle the babel process within the component directory. 