### PR TITLE
Close compiler after run

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -12,5 +12,10 @@ module.exports = function (env, args) {
         appendScriptTag: true,
       }),
     ],
+    cache: {
+      buildDependencies: {
+        config: [__filename],
+      },
+    },
   });
 };

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -49,5 +49,10 @@ module.exports = function (env, args) {
         }),
       ],
     },
+    cache: {
+      buildDependencies: {
+        config: [__filename],
+      },
+    },
   });
 };

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -126,5 +126,10 @@ module.exports = function (env, args) {
           },
         }),
     ].filter(Boolean),
+    cache: {
+      buildDependencies: {
+        config: [__filename],
+      },
+    },
   });
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -107,10 +107,12 @@ function build(environment, previousFileSizes) {
         return reject(new Error(messages.warnings.join('\n\n')));
       }
 
-      return resolve({
-        stats,
-        previousFileSizes,
-        warnings: messages.warnings,
+      compiler.close(() => {
+        return resolve({
+          stats,
+          previousFileSizes,
+          warnings: messages.warnings,
+        });
       });
     });
   });


### PR DESCRIPTION
This change closes the compiler after it ran successfully. Not closing ist could result in performance issues, above all the close process writes the cache files, resulting in much faster builds. While the cache is already configured, it had no effect because of an unclosed compile process.

Needs to be tested since I don't have any project with this package any more