### PR TITLE
Read package name from env if not found in package.json

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -25,8 +25,8 @@ const createEnvHash = require('../helpers/createEnvHash');
 
 const paths = require('./paths');
 
-const basePackageName = process.env['npm_package_basePackageName'];
-const sitePackageName = process.env['npm_package_sitePackageName'];
+const basePackageName = process.env['npm_package_basePackageName'] || process.env['BASE_PACKAGE_NAME'];
+const sitePackageName = process.env['npm_package_sitePackageName'] || process.env['SITE_PACKAGE_NAME'];
 const useTypeScript = fs.existsSync(paths.misc.tsConfig);
 const customerName = basePackageName.split('.')[0];
 const clientEnv = getClientEnv({ CUSTOMER_NAME: customerName });


### PR DESCRIPTION
(Re-)adds support for `BASE_PACKAGE_NAME` and `SITE_PACKAGE_NAME` .env file

The reason is that yarn workspaces seem to have problems reading from `npm_package_xxx`

The `npm_package_...` variables are readable from the site directory but as workspaces use root package.json (which overwrites local directory variables)