### PR TITLE
Typescript Linting: Ignore node_modules on default

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -36,6 +36,10 @@ const iconPath = path.resolve(
   basePackagePathAbsolute(),
   paths.sources.iconPath
 );
+const tsConfigPath = path.resolve(
+  basePackagePathAbsolute(),
+  paths.misc.tsConfig
+);
 const modernizrBaseConfig = require(paths.sources.modernizrBasePath);
 let modernizrCustomConfig = {};
 
@@ -271,10 +275,21 @@ module.exports = function (webpackEnv, args) {
       useTypeScript &&
         new ForkTsCheckerWebpackPlugin({
           async: isEnvDevelopment,
+          issue: {
+            exclude: (issue) => {
+              // ignore liniting errors from node modules
+              // we do not want to exclude node_modules from compilation
+              if (String(issue.file).includes('/node_modules/')) {
+                return true
+              }
+              return false
+            }
+          },
           typescript: {
             typescriptPath: resolve.sync('typescript', {
               basedir: paths.sources.appNodeModules,
             }),
+            configFile: tsConfigPath,
             configOverwrite: {
               compilerOptions: {
                 sourceMap: isEnvDevelopment,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@networkteam/frontend-scripts",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "networkteam asset build scripts",
   "bin": {
     "networkteam-asset-build": "./bin/cli.js"


### PR DESCRIPTION
We do not want `ForkTsCheckerWebpackPlugin` to Auto-Lint Files from inside `node_modules`

Also adds path to tsconfig.json in Plugin so that entries are actually validated.