### PR TITLE
Fix: Use actual deep Merge instead of shallow merging webpack plugins

### DIFF
--- a/helpers/configHelpers.js
+++ b/helpers/configHelpers.js
@@ -33,7 +33,7 @@ function deleteRemovedKeys(defaultConfig, customConfig) {
 }
 
 /**
- * merges plugins of customConfig in defaultConfig and deletes customConf.plugins afterwards, so that they are being initialized only once.
+ * merges plugins of customConfig in defaultConfig if they were also defined in defaultConfig then removes them from initialization array once, so that they are being initialized only once.
 
  * @param {object} defaultConfig default configuration in current environment
  * @param {object} customConfig custom configuration from project in current environment
@@ -44,20 +44,52 @@ function mergeConfigPlugins(defaultConfig, customConfig) {
   let customConf = customConfig;
 
   if (customConf.plugins) {
-    defaultConf.plugins =
-      defaultConf.plugins.map((plugin) => {
-        const customPlugin = customConf.plugins.find(
-          (customPlugin) => customPlugin.constructor.name === plugin.constructor.name
-        );
-        if (customPlugin) {
-          return Object.assign(plugin, customPlugin);
-        }
-        return plugin;
-      })
-
-      delete customConf.plugins;
+    defaultConf.plugins = defaultConf.plugins.map((plugin) => {
+      // finds duplicated plugin in custom config
+      const customPlugin = customConf.plugins.find(
+        (customPlugin) => customPlugin.constructor.name === plugin.constructor.name
+      );
+      if (customPlugin) {
+        const mergedPlugin = mergeDeep(plugin, customPlugin);
+        // removes plugin from custom config so it is not initialized twice
+        customConf.plugins.splice(customConf.plugins.indexOf(customPlugin), 1);
+        return mergedPlugin
+      }
+      return plugin;
+    });
   }
   return {defaultConf, customConf};
+}
+
+function isObject(item) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+/**
+ * recursively merges two objects by keys
+
+ * @param {object} target target object to merge into
+ * @param {object} sources target object to merge from
+ */
+
+function mergeDeep(target, ...sources) {
+  if (!sources.length) return target;
+  const source = sources.shift();
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, {
+          [key]: {}
+        });
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, {
+          [key]: source[key]
+        });
+      }
+    }
+  }
+  return mergeDeep(target, ...sources);
 }
 
 function getOutputPath(environment) {

--- a/helpers/configHelpers.spec.js
+++ b/helpers/configHelpers.spec.js
@@ -11,6 +11,12 @@ describe('configHelpers', function () {
     const mockSassLoader = function () {};
     const mockAutoprefixerPlugin = function () {};
 
+    class SVGSpritemapPlugin {
+      constructor(options) {
+        this.options = options;
+      }
+    }
+
     const defaultConfiguration = function (env, args) {
       const mode = args.mode;
       return {
@@ -56,6 +62,21 @@ describe('configHelpers', function () {
             },
           ],
         },
+        plugins: [
+          new SVGSpritemapPlugin({
+            output: {
+              filename: `iconsprite-frontend-scripts.svg`,
+            },
+            styles: {
+              filename: 'a path to a file',
+              variables: {
+                sizes: 'nwtSizes',
+                sprites: 'nwtSprites',
+                variables: 'nwtVariables',
+              },
+            },
+          }),
+        ],
       };
     };
 
@@ -120,6 +141,50 @@ describe('configHelpers', function () {
               plugins: [mockTailwindPlugin, mockAutoprefixerPlugin],
             },
             sourceMap: true,
+          },
+        });
+      });
+    });
+
+    describe('with existing plugin with overwritten config', function () {
+      const mockTailwindPlugin = function () {};
+
+      const customConfiguration = function (env, args) {
+        return {
+          plugins: [
+            new SVGSpritemapPlugin({
+              output: {
+                filename: `a different file name`,
+              },
+            }),
+          ],
+        };
+      };
+
+      it('replaces output filename and keeps rest of the config', function () {
+        const config = combineConfigurations(
+          defaultConfiguration,
+          customConfiguration
+        )('dev', { mode: 'development' });
+        console.log(
+          'lelele',
+          config.plugins[0].options.output.filename
+        );
+        expect(config.plugins).to.have.length(1);
+        expect(config.plugins[0].options.output.filename).to.equal(
+          'a different file name'
+        );
+        expect(config.plugins[0].options).to.deep.eq({
+          output: {
+            filename: `a different file name`,
+          },
+          styles: {
+            filename: 'a path to a file',
+            variables: {
+              sizes: 'nwtSizes',
+              sprites: 'nwtSprites',
+              variables: 'nwtVariables',
+            },
           },
         });
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@networkteam/frontend-scripts",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "networkteam asset build scripts",
   "bin": {
     "networkteam-asset-build": "./bin/cli.js"


### PR DESCRIPTION
Switches out merging mechanis of webpack plugins merge.
This is an improvement and also a bugfix.

Improvement:
* When a plugin is defined in custom webpack config that is already defined in `common.webpack.js` it is treated as one plugin that takes the default config and merges config of custom Webpack-Plugin onto it. This now also effects deeply nested configurations.

* added tests for feature

Bugfix: 
* Fixes a bug where custom defined plugins in config would not be initialized

**Note:**
Deeply merging constructors only goes so far. If a default value of any used plugin in custom webpack config is initialized then it will overwrite the value defined in default config. 
