### PR TITLE
Webpack Test-Config: Ignore TS-Linting in node_modules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ module.exports = function(env, args) {
 
 To remove entry points from webpack, you can set them to null in your own configuration
 
+When a plugin is defined in custom webpack config that is already defined in common.webpack.js it is treated as one plugin that takes the default config and merges config of custom Webpack-Plugin deeply into it. Deeply merging class constructors only goes so far. If a default value of any used plugin in custom webpack config is initialized then it will overwrite the value defined in default config.
+
 ## Using modernizr
 
 By default a modernizr custom build is generated with `setclasses` option and can be imported via

--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -100,6 +100,16 @@ module.exports = function (env, args) {
       useTypeScript &&
         new ForkTsCheckerWebpackPlugin({
           async: true,
+          issue: {
+            exclude: (issue) => {
+              // ignore liniting errors from node modules
+              // we do not want to exclude node_modules from compilation
+              if (String(issue.file).includes('/node_modules/')) {
+                return true
+              }
+              return false
+            }
+          },
           typescript: {
             typescriptPath: resolve.sync('typescript', {
               basedir: paths.sources.appNodeModules,
@@ -122,7 +132,7 @@ module.exports = function (env, args) {
             mode: 'write-references',
           },
           logger: {
-            infrastructure: 'silent',
+            infrastructure: 'console',
           },
         }),
     ].filter(Boolean),


### PR DESCRIPTION
Adapts webpack test config in the same way we handled ts-linting errors in node_modules for prod builds.