### PR TITLE
Feature: `--noLivereload` flag for dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ This workflow automatically provides aliases for an easier import from different
 
 Every SVG-File located in `%BASEROOT%/Resources/Private/Icons` will be included in an automatically generated Svgsprite. The sprite itself will be stored in `%BASEROOT%/Resources/Public/Dist` and a SCSS-File can be found in `%BASEROOT%/Resources/Private/Scss/_sprite.scss`. This SCSS-File includes the mixins to use the icon on every element (`@include sprite(%FILENAME%)`) although this way is not encouraged due to repeated server requests.
 
-To prevent Iconsprite from being built, use the `--noIconSprite` Flag in your npm tasks
+To prevent Iconsprite from being built, use the `--noIconSprite` flag in your npm scripts. This might be useful when on projects where you don't want to do that for each build.
+
+## Live Reloading
+
+Hot or live reloading is supported by default in development mode. In certain projects it makes sense to disable live reloading and refresh the view manually (e.g. in forms).
+
+To disable live reloading, use the `--noLivereload` flag in your npm scripts.
 
 ## Environment Variables
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -4,13 +4,17 @@ const common = require('./webpack.common.js');
 
 module.exports = function (env, args) {
   args.mode = 'development';
+  const enableLivereload = args['noLivereload'] ? false : true;
+  const livereloadPlugin = enableLivereload ? [
+    new LiveReloadPlugin({
+      appendScriptTag: true,
+    })
+  ] : []
   return merge(common(env, args), {
     // CSS loaders need inline source maps to work correctly
     devtool: 'inline-source-map',
     plugins: [
-      new LiveReloadPlugin({
-        appendScriptTag: true,
-      }),
+      ...livereloadPlugin
     ],
     cache: {
       buildDependencies: {


### PR DESCRIPTION
In some rare instances it makes sense for developers to disable live-reload because developers might want to trigger a page reload manually. 

For cases like this support for another argument flag is being proposed.

Adding `--noLivereload` to the npm dev command disables live reloading in development context.